### PR TITLE
feat: OGImage対応 #147

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -43,6 +43,13 @@ const { title, description, image = "/hero.webp" } = Astro.props;
 <meta name="title" content={title} />
 <meta name="description" content={description} />
 
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content={Astro.url} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={new URL(image, Astro.url)} />
+
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:url" content={Astro.url} />


### PR DESCRIPTION
## Summary
- BaseHead.astroにOpen Graphメタタグを追加
- SNSでのリンク共有時に適切なプレビューが表示されるように対応

## 変更内容
- `og:type`, `og:url`, `og:title`, `og:description`, `og:image`タグを追加
- 既存のTwitterカードタグと併用して、Facebook、LinkedIn、Slackなど幅広いプラットフォームに対応
- ブログ記事では各記事のheroImageが、トップページではデフォルトの`/hero.webp`がOGImageとして使用される

## Test plan
- [ ] ビルドが正常に完了することを確認
- [ ] HTMLにOGタグが正しく出力されることを確認
- [ ] 各種SNSシェアデバッガーでプレビューを確認
  - [ ] Facebook: https://developers.facebook.com/tools/debug/
  - [ ] Twitter: https://cards-dev.twitter.com/validator
  - [ ] LinkedIn: https://www.linkedin.com/post-inspector/

Closes #147

🤖 Generated with [Claude Code](https://claude.ai/code)