### PR TITLE
refactor: トップページを年ごとのシンプルなリスト形式に変更

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -7,19 +7,18 @@ import FormattedDate from "../components/FormattedDate.astro";
 
 type Props = CollectionEntry<"blog">["data"];
 
-const { title, pubDate, updatedDate, heroImage } = Astro.props;
+const { title, pubDate, updatedDate } = Astro.props;
 ---
 
 <html lang="ja">
     <head>
-        <BaseHead title={title} description={title} image={heroImage} />
+        <BaseHead title={title} description={title} />
         <style>
             main {
                 width: calc(100% - 2em);
                 max-width: 100%;
                 margin: 0;
             }
-            /* .hero-image styles are now applied within .title */
             .prose {
                 width: 720px;
                 max-width: calc(100% - 2em);
@@ -33,29 +32,7 @@ const { title, pubDate, updatedDate, heroImage } = Astro.props;
             .title {
                 margin-bottom: 1em;
                 padding: 1em 0;
-                /* text-align: center; */ /* Removed */
                 line-height: 1;
-                display: flex; /* Added */
-                align-items: center; /* Added */
-            }
-            .title .hero-image {
-                /* Style for image container inside title */
-                margin-right: 1em;
-                flex-shrink: 0;
-            }
-            .title .hero-image img {
-                /* Style for image inside title */
-                max-width: 80px; /* Make image smaller */
-                width: 100%;
-                /* opacity: 0.8; */ /* Opacity removed for now */
-                border-radius: 8px;
-                box-shadow: var(--box-shadow);
-                vertical-align: middle; /* Helps alignment */
-            }
-            .title-content {
-                /* New container for date/h1 */
-                flex-grow: 1;
-                text-align: left; /* Align text left */
             }
             .title h1 {
                 margin: 0 0 0.5em 0;
@@ -77,35 +54,19 @@ const { title, pubDate, updatedDate, heroImage } = Astro.props;
             <article>
                 <div class="prose">
                     <div class="title">
-                        {/* Moved hero image here */}
-                        {
-                            heroImage && (
-                                <div class="hero-image">
-                                    <img
-                                        width={1020}
-                                        height={510}
-                                        src={heroImage}
-                                        alt=""
-                                    />
-                                </div>
-                            )
-                        }
-                        {/* Added title-content wrapper */}
-                        <div class="title-content">
-                            <div class="date">
-                                <FormattedDate date={pubDate} />
-                                {
-                                    updatedDate && (
-                                        <div class="last-updated-on">
-                                            Last updated on{" "}
-                                            <FormattedDate date={updatedDate} />
-                                        </div>
-                                    )
-                                }
-                            </div>
-                            <h1>{title}</h1>
-                            <hr />
+                        <div class="date">
+                            <FormattedDate date={pubDate} />
+                            {
+                                updatedDate && (
+                                    <div class="last-updated-on">
+                                        Last updated on{" "}
+                                        <FormattedDate date={updatedDate} />
+                                    </div>
+                                )
+                            }
                         </div>
+                        <h1>{title}</h1>
+                        <hr />
                     </div>
                     <slot />
                 </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,33 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 import { getCollection } from "astro:content";
-import FormattedDate from "../components/FormattedDate.astro";
 
 const posts = (await getCollection("blog")).sort(
     (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
+
+// 年ごとにグループ化
+const postsByYear = posts.reduce(
+    (acc, post) => {
+        const year = post.data.pubDate.getFullYear();
+        if (!acc[year]) acc[year] = [];
+        acc[year].push(post);
+        return acc;
+    },
+    {} as Record<number, typeof posts>,
+);
+
+const years = Object.keys(postsByYear)
+    .map(Number)
+    .sort((a, b) => b - a);
+
+// 日付をフォーマットする関数
+const formatDate = (date: Date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+};
 ---
 
 <!doctype html>
@@ -19,106 +41,83 @@ const posts = (await getCollection("blog")).sort(
             main {
                 width: 960px;
             }
+            .year-section {
+                margin-bottom: 2rem;
+            }
+            .year-heading {
+                font-size: 1.5rem;
+                font-weight: bold;
+                margin: 0 0 1rem 0;
+                color: rgb(var(--black));
+                border-bottom: 1px solid rgb(var(--gray-light));
+                padding-bottom: 0.5rem;
+            }
             ul {
-                display: flex;
-                flex-wrap: wrap;
-                gap: 2rem;
                 list-style-type: none;
                 margin: 0;
                 padding: 0;
             }
             ul li {
-                /* 3列表示になるように幅を調整 (gap: 2rem を考慮) */
-                width: calc(33.33% - 1.34rem);
-            }
-            ul li * {
-                text-decoration: none;
-                transition: 0.2s ease;
-            }
-            /* ul li:first-child {
-                width: 100%;  <- 3列表示のため削除
-                margin-bottom: 1rem;
-                text-align: center;
-            } */
-            ul li:first-child img {
-                /* width: 100%; <- first-childの特別扱いをやめるため削除しても良いが、影響なければ残す */
-            }
-            /* ul li:first-child .title {
-                font-size: 2.369rem; <- 最初の投稿のタイトルを特別扱いしないため削除
-            } */
-            ul li img {
-                height: 150px; /* 固定の高さを設定 */
-                object-fit: cover; /* 比率を保ちつつ領域を埋める */
                 margin-bottom: 0.5rem;
-                border-radius: 12px;
-                flex-shrink: 0; /* 画像が縮まないようにする */
             }
             ul li a {
-                display: flex; /* Flexコンテナにする */
-                flex-direction: column; /* 子要素を縦に並べる */
-                height: 100%; /* liの高さいっぱいに広げる */
-            }
-            .title {
-                flex-grow: 1; /* タイトル部分が残りのスペースを埋める */
-                margin: 0 0 0.25rem 0; /* 下マージンを少し追加 */
+                display: inline-block;
+                text-decoration: none;
                 color: rgb(var(--black));
-                line-height: 1;
+                transition: color 0.2s ease;
             }
-            .date {
-                margin: 0;
-                color: rgb(var(--gray));
-            }
-            ul li a:hover h4,
-            ul li a:hover .date {
+            ul li a:hover {
                 color: rgb(var(--accent));
             }
-            ul a:hover img {
-                box-shadow: var(--box-shadow);
+            .date {
+                color: rgb(var(--gray));
+                font-family: monospace;
+                margin-right: 1rem;
+            }
+            .title {
+                color: inherit;
             }
             @media (max-width: 720px) {
-                ul {
-                    gap: 0.5em;
+                .year-section {
+                    margin-bottom: 1.5rem;
                 }
                 ul li {
-                    width: 100%;
-                    text-align: center;
+                    margin-bottom: 0.75rem;
                 }
-                ul li:first-child {
-                    margin-bottom: 0;
+                ul li a {
+                    display: block;
                 }
-                /* ul li:first-child .title {
-                    font-size: 1.563em; <- モバイルでも最初の投稿のタイトルを特別扱いしないため削除
-                } */
+                .date {
+                    display: block;
+                    margin-bottom: 0.25rem;
+                }
             }
         </style>
     </head>
     <body>
         <Header />
         <main>
-            <section>
-                <ul>
-                    {
-                        posts.map((post) => (
-                            <li>
-                                <a href={`/${post.slug}/`}>
-                                    <img
-                                        width={720}
-                                        height={360}
-                                        src={post.data.heroImage}
-                                        alt=""
-                                    />
-                                    <h4 class="title">{post.data.title}</h4>
-                                    <p class="date">
-                                        <FormattedDate
-                                            date={post.data.pubDate}
-                                        />
-                                    </p>
-                                </a>
-                            </li>
-                        ))
-                    }
-                </ul>
-            </section>
+            {
+                years.map((year) => (
+                    <section class="year-section">
+                        <h2 class="year-heading">{year}</h2>
+                        <ul>
+                            {postsByYear[year].map((post) => (
+                                <li>
+                                    <a href={`/${post.slug}/`}>
+                                        <span class="date">
+                                            {formatDate(post.data.pubDate)}
+                                        </span>
+                                        <span class="title">
+                                            {post.data.title}
+                                        </span>
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                ))
+            }
         </main>
         <Footer />
     </body>


### PR DESCRIPTION
## Summary
- トップページの記事一覧を3列グリッド+画像形式から年ごとにグルーピングしたシンプルなリスト形式に変更
- 各記事を「YYYY-MM-DD タイトル」の1行形式で表示
- ブログ記事ページからもheroImageを削除してシンプルなレイアウトに

## Test plan
- [ ] トップページで年ごとにセクションが分かれているか確認
- [ ] 各記事が「日付 タイトル」形式で表示されているか確認
- [ ] 画像が表示されていないか確認
- [ ] リンクが正しく機能するか確認
- [ ] モバイル表示でも問題ないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)