### PR TITLE
feat: ZennやQiitaの外部記事をトップページに表示する機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,18 @@ npm run textlint:fix
 
 ### コンテンツ管理
 - **ブログ記事**: `src/content/blog/*.md` - Front Matterで管理されたMarkdownファイル
-- **必須Front Matter項目**:
+- **外部記事**: `src/content/external/*.md` - Zenn/Qiitaなど外部プラットフォームの記事リンク
+- **必須Front Matter項目（ブログ記事）**:
   - `title`: 記事タイトル
   - `description`: 記事の説明文
   - `pubDate`: 公開日（日付型）
   - `updatedDate`: 更新日（オプション）
   - `heroImage`: ヒーロー画像パス（オプション、`/public/`からの相対パス）
+- **必須Front Matter項目（外部記事）**:
+  - `title`: 記事タイトル
+  - `pubDate`: 公開日（日付型）
+  - `url`: 外部記事のURL
+  - `platform`: `zenn` / `qiita` / `other` のいずれか
 
 ### ページ構成
 - `src/pages/index.astro`: トップページ（ブログ記事一覧、3列グリッドレイアウト）
@@ -95,6 +101,25 @@ npm run textlint:fix
 3. `npm run textlint` で文章チェック
 4. `npm run build` でビルド確認
 5. GitHubにプッシュすると自動デプロイ
+
+## 外部記事（Zenn/Qiita）の追加方法
+
+ZennやQiitaなど外部プラットフォームに投稿した記事をトップページに表示できる。
+
+1. `src/content/external/` に `YYYY-MM-DD-タイトル.md` 形式でファイル作成
+2. 以下のFront Matterを記述:
+   ```yaml
+   ---
+   title: 記事タイトル
+   pubDate: 2025-01-24
+   url: https://zenn.dev/xxx/articles/xxx
+   platform: zenn
+   ---
+   ```
+3. `platform` は `zenn` / `qiita` / `other` から選択
+4. 本文は空でもよい（メモとして使用可能）
+5. トップページで自分のブログ記事と時系列で混在表示される
+6. 外部記事は `↗` アイコンとプラットフォームタグ付きで表示
 
 ## 画像の扱い
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ npm run new
 2. heroImage（アイキャッチ画像）を番号で選択（空エンターでスキップ）
 3. `src/content/blog/YYYY-MM-DD-タイトル.md` が生成される
 4. 生成されたファイルを開いて本文を書く
+
+## 外部記事（Zenn/Qiita）の追加方法
+
+ZennやQiitaに投稿した記事をトップページに表示できます。
+
+1. `src/content/external/` に `YYYY-MM-DD-タイトル.md` 形式でファイル作成
+2. Front Matterを記述:
+   ```yaml
+   ---
+   title: 記事タイトル
+   pubDate: 2025-01-24
+   url: https://zenn.dev/xxx/articles/xxx
+   platform: zenn
+   ---
+   ```
+3. `platform` は `zenn` / `qiita` / `other` から選択
+4. トップページで自分のブログ記事と時系列で混在表示されます

--- a/frontmatter.json
+++ b/frontmatter.json
@@ -30,6 +30,37 @@
           "isPreviewImage": true
         }
       ]
+    },
+    {
+      "name": "external",
+      "pageBundle": false,
+      "clearEmpty": true,
+      "fields": [
+        {
+          "name": "title",
+          "type": "string",
+          "single": true,
+          "required": true
+        },
+        {
+          "name": "pubDate",
+          "type": "datetime",
+          "default": "{{now}}",
+          "required": true
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "single": true,
+          "required": true
+        },
+        {
+          "name": "platform",
+          "type": "choice",
+          "choices": ["zenn", "qiita", "other"],
+          "required": true
+        }
+      ]
     }
   ],
   "frontMatter.framework.id": "astro",
@@ -40,6 +71,13 @@
       "path": "[[workspace]]/src/content/blog",
       "contentTypes": [
         "blog"
+      ]
+    },
+    {
+      "title": "external",
+      "path": "[[workspace]]/src/content/external",
+      "contentTypes": [
+        "external"
       ]
     }
   ],

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -12,4 +12,14 @@ const blog = defineCollection({
 	}),
 });
 
-export const collections = { blog };
+const external = defineCollection({
+	type: 'content',
+	schema: z.object({
+		title: z.string(),
+		pubDate: z.coerce.date(),
+		url: z.string().url(),
+		platform: z.enum(['zenn', 'qiita', 'other']),
+	}),
+});
+
+export const collections = { blog, external };

--- a/src/content/external/2023-05-08-vercelで簡単に実装-cron-jobsの設定方法と活用例.md
+++ b/src/content/external/2023-05-08-vercelで簡単に実装-cron-jobsの設定方法と活用例.md
@@ -1,0 +1,6 @@
+---
+title: Vercelで簡単に実装！Cron Jobsの設定方法と活用例
+pubDate: 2023-05-08
+url: https://zenn.dev/ryosuke_horie/articles/7374a83566c6b7
+platform: zenn
+---

--- a/src/content/external/2023-07-26-nextjs-material-uiの導入.md
+++ b/src/content/external/2023-07-26-nextjs-material-uiの導入.md
@@ -1,0 +1,6 @@
+---
+title: Next.js Material-UIの導入
+pubDate: 2023-07-26
+url: https://zenn.dev/ryosuke_horie/articles/ce00a0893c96d0
+platform: zenn
+---

--- a/src/content/external/2023-07-29-nvmのアップデート-nodeバージョン変更.md
+++ b/src/content/external/2023-07-29-nvmのアップデート-nodeバージョン変更.md
@@ -1,0 +1,6 @@
+---
+title: nvmのアップデート・nodeバージョン変更
+pubDate: 2023-07-29
+url: https://zenn.dev/ryosuke_horie/articles/8f7d79d277172f
+platform: zenn
+---

--- a/src/content/external/2023-08-13-aws-nestjs-ec2でnestjsアプリケーションをデプロイする.md
+++ b/src/content/external/2023-08-13-aws-nestjs-ec2でnestjsアプリケーションをデプロイする.md
@@ -1,0 +1,6 @@
+---
+title: 【AWS】【Nest.js】EC2でNest.jsアプリケーションをデプロイする
+pubDate: 2023-08-13
+url: https://zenn.dev/ryosuke_horie/articles/547e24c5cf6d75
+platform: zenn
+---

--- a/src/content/external/2023-08-21-nestjsアプリケーションをec2インスタンス上で永続的に起動させる.md
+++ b/src/content/external/2023-08-21-nestjsアプリケーションをec2インスタンス上で永続的に起動させる.md
@@ -1,0 +1,6 @@
+---
+title: Nest.jsアプリケーションをEC2インスタンス上で永続的に起動させる
+pubDate: 2023-08-21
+url: https://zenn.dev/ryosuke_horie/articles/986366b0b1c7c8
+platform: zenn
+---

--- a/src/content/external/2023-08-30-nextjsでホワイトリスト形式のip制限をかける.md
+++ b/src/content/external/2023-08-30-nextjsでホワイトリスト形式のip制限をかける.md
@@ -1,0 +1,6 @@
+---
+title: Next.jsでホワイトリスト形式のIP制限をかける
+pubDate: 2023-08-30
+url: https://zenn.dev/ryosuke_horie/articles/8f1ccdf7bbe40d
+platform: zenn
+---

--- a/src/content/external/2023-11-22-gitlab-runnerのインストールと初期設定.md
+++ b/src/content/external/2023-11-22-gitlab-runnerのインストールと初期設定.md
@@ -1,0 +1,6 @@
+---
+title: Gitlab Runnerのインストールと初期設定
+pubDate: 2023-11-22
+url: https://qiita.com/ryosuke-horie/items/438974ec5796b9b0f390
+platform: qiita
+---

--- a/src/content/external/2023-12-17-aws-codeシリーズやgitlabciを利用したcicdを早くするために実践したこと.md
+++ b/src/content/external/2023-12-17-aws-codeシリーズやgitlabciを利用したcicdを早くするために実践したこと.md
@@ -1,0 +1,6 @@
+---
+title: AWS CodeシリーズやGitLabCIを利用したCICDを早くするために実践したこと
+pubDate: 2023-12-17
+url: https://zenn.dev/ryosuke_horie/articles/83845f869de920
+platform: zenn
+---

--- a/src/content/external/2023-12-17-aws-dva合格体験記.md
+++ b/src/content/external/2023-12-17-aws-dva合格体験記.md
@@ -1,0 +1,6 @@
+---
+title: AWS DVA(DVA-C02)合格体験記
+pubDate: 2023-12-17
+url: https://qiita.com/ryosuke-horie/items/664ce167ace2deff9df9
+platform: qiita
+---

--- a/src/content/external/2024-01-23-aws-waf-動画ファイルアップロード処理で誤検出されてしまう問題への対応.md
+++ b/src/content/external/2024-01-23-aws-waf-動画ファイルアップロード処理で誤検出されてしまう問題への対応.md
@@ -1,0 +1,6 @@
+---
+title: AWS WAF 動画ファイルアップロード処理で誤検出されてしまう問題への対応
+pubDate: 2024-01-23
+url: https://qiita.com/ryosuke-horie/items/e3953a28c68ad146803f
+platform: qiita
+---

--- a/src/content/external/2024-01-23-サーバーのタイムゾーン設定が原因でssmがエラーになっていた.md
+++ b/src/content/external/2024-01-23-サーバーのタイムゾーン設定が原因でssmがエラーになっていた.md
@@ -1,0 +1,6 @@
+---
+title: サーバーのタイムゾーン設定が原因でSSMがエラーになっていた
+pubDate: 2024-01-23
+url: https://qiita.com/ryosuke-horie/items/6077f53120d7a6ad84c5
+platform: qiita
+---

--- a/src/content/external/2024-03-18-alb-cloudfront間ssl-tls対応記録.md
+++ b/src/content/external/2024-03-18-alb-cloudfront間ssl-tls対応記録.md
@@ -1,0 +1,6 @@
+---
+title: ALB⇔CloudFront間SSL/TLS対応記録
+pubDate: 2024-03-18
+url: https://zenn.dev/ryosuke_horie/articles/1a8a03bfd4c13a
+platform: zenn
+---

--- a/src/content/external/2024-03-25-cloudfront-spaをホストする場合リダイレクトさせる.md
+++ b/src/content/external/2024-03-25-cloudfront-spaをホストする場合リダイレクトさせる.md
@@ -1,0 +1,6 @@
+---
+title: 【Cloudfront】 SPAをホストする場合、「/」以外のアクセスでリダイレクトさせる
+pubDate: 2024-03-25
+url: https://qiita.com/ryosuke-horie/items/707aafe1e546a5dbf77a
+platform: qiita
+---

--- a/src/content/external/2024-03-25-デプロイ後にcloudfrontのキャッシュ削除をlambda関数で自動化する.md
+++ b/src/content/external/2024-03-25-デプロイ後にcloudfrontのキャッシュ削除をlambda関数で自動化する.md
@@ -1,0 +1,6 @@
+---
+title: デプロイ後にCloudFrontのキャッシュ削除をLambda関数で自動化する
+pubDate: 2024-03-25
+url: https://qiita.com/ryosuke-horie/items/8869423d1a318c273970
+platform: qiita
+---

--- a/src/content/external/2024-04-19-laravel10-laravel11を2つのプロジェクトで対応しました.md
+++ b/src/content/external/2024-04-19-laravel10-laravel11を2つのプロジェクトで対応しました.md
@@ -1,0 +1,6 @@
+---
+title: Laravel10→Laravel11を2つのプロジェクトで対応しました
+pubDate: 2024-04-19
+url: https://zenn.dev/ryosuke_horie/articles/abb3339095593d
+platform: zenn
+---

--- a/src/content/external/2024-06-23-awsで動かすai要約機能付きrssリーダーを自作してみた.md
+++ b/src/content/external/2024-06-23-awsで動かすai要約機能付きrssリーダーを自作してみた.md
@@ -1,0 +1,6 @@
+---
+title: AWSで動かすAI要約機能付きRSSリーダーを自作してみた
+pubDate: 2024-06-23
+url: https://zenn.dev/ryosuke_horie/articles/71eb52b23a3f2d
+platform: zenn
+---

--- a/src/content/external/2024-07-04-開発環境を改善するためにチームに提案して実践したこと.md
+++ b/src/content/external/2024-07-04-開発環境を改善するためにチームに提案して実践したこと.md
@@ -1,0 +1,6 @@
+---
+title: 開発環境を改善するためにチームに提案して実践したこと
+pubDate: 2024-07-04
+url: https://qiita.com/ryosuke-horie/items/c2d02da4784b785b0911
+platform: qiita
+---

--- a/src/content/external/2024-09-03-githubセルフホストランナー導入の記録.md
+++ b/src/content/external/2024-09-03-githubセルフホストランナー導入の記録.md
@@ -1,0 +1,6 @@
+---
+title: GitHubセルフホストランナー導入の記録
+pubDate: 2024-09-03
+url: https://zenn.dev/ryosuke_horie/articles/eb24a358033047
+platform: zenn
+---

--- a/src/content/external/2024-10-19-対応漏れを防ぐために-githubと連携するツールを開発してみた.md
+++ b/src/content/external/2024-10-19-対応漏れを防ぐために-githubと連携するツールを開発してみた.md
@@ -1,0 +1,6 @@
+---
+title: 対応漏れを防ぐために：GitHubと連携するツールを開発してみた
+pubDate: 2024-10-19
+url: https://zenn.dev/ryosuke_horie/articles/b372a6a1db11cd
+platform: zenn
+---

--- a/src/content/external/2025-03-02-github-actions-openhandsでプロジェクトの自動改善提案botを作ってみた.md
+++ b/src/content/external/2025-03-02-github-actions-openhandsでプロジェクトの自動改善提案botを作ってみた.md
@@ -1,0 +1,6 @@
+---
+title: GitHub Actions × OpenHandsでプロジェクトの自動改善提案Botを作ってみた
+pubDate: 2025-03-02
+url: https://zenn.dev/ryosuke_horie/articles/2b2101b2394cd3
+platform: zenn
+---

--- a/src/content/external/2025-04-08-cloudflare-agentのテンプレートを少しだけいじってわかったこと.md
+++ b/src/content/external/2025-04-08-cloudflare-agentのテンプレートを少しだけいじってわかったこと.md
@@ -1,0 +1,6 @@
+---
+title: Cloudflare Agentのテンプレートを少しだけいじってわかったこと
+pubDate: 2025-04-08
+url: https://zenn.dev/ryosuke_horie/articles/4d0a2e5af4fddc
+platform: zenn
+---

--- a/src/content/external/2025-04-12-devinを使ってapi+フロントを一括実装してみたメモ.md
+++ b/src/content/external/2025-04-12-devinを使ってapi+フロントを一括実装してみたメモ.md
@@ -1,0 +1,6 @@
+---
+title: Devin を使って API + フロントを一括実装してみたメモ（ACU 4$分）
+pubDate: 2025-04-12
+url: https://zenn.dev/ryosuke_horie/articles/2b74749e8f5ff7
+platform: zenn
+---

--- a/src/content/external/2025-06-22-claudeのmaxプランによって変わった個人開発のスタイル.md
+++ b/src/content/external/2025-06-22-claudeのmaxプランによって変わった個人開発のスタイル.md
@@ -1,0 +1,6 @@
+---
+title: ClaudeのMaxプランによって変わった個人開発のスタイル
+pubDate: 2025-06-22
+url: https://zenn.dev/ryosuke_horie/articles/24768b727ff27c
+platform: zenn
+---

--- a/src/content/external/2025-07-27-claude-codeのsub-agentでコードレビューと改善のサイクルの自動化を試行錯誤した.md
+++ b/src/content/external/2025-07-27-claude-codeのsub-agentでコードレビューと改善のサイクルの自動化を試行錯誤した.md
@@ -1,0 +1,6 @@
+---
+title: Claude CodeのSub agentでコードレビューと改善のサイクルの自動化を試行錯誤した
+pubDate: 2025-07-27
+url: https://zenn.dev/ryosuke_horie/articles/41725ccfd74ea7
+platform: zenn
+---

--- a/src/content/external/2025-09-19-claude-code-action-v1で日本語で自動でインラインレビューする.md
+++ b/src/content/external/2025-09-19-claude-code-action-v1で日本語で自動でインラインレビューする.md
@@ -1,0 +1,6 @@
+---
+title: Claude Code Action v1で日本語で自動でインラインレビューする(v1.0.8)
+pubDate: 2025-09-19
+url: https://zenn.dev/ryosuke_horie/articles/328fcce809ed9f
+platform: zenn
+---

--- a/src/content/external/2025-11-23-codexでvibe-kanban-mcpが起動できない警告への対応.md
+++ b/src/content/external/2025-11-23-codexでvibe-kanban-mcpが起動できない警告への対応.md
@@ -1,0 +1,6 @@
+---
+title: CodexでVibe Kanban MCPが起動できない警告への対応
+pubDate: 2025-11-23
+url: https://zenn.dev/ryosuke_horie/articles/23ab8b69b06f3b
+platform: zenn
+---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,19 +5,44 @@ import Footer from "../components/Footer.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 import { getCollection } from "astro:content";
 
-const posts = (await getCollection("blog")).sort(
-    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+type Post = {
+    type: "blog" | "external";
+    slug: string;
+    title: string;
+    pubDate: Date;
+    url?: string;
+    platform?: "zenn" | "qiita" | "other";
+};
+
+const blogPosts = await getCollection("blog");
+const externalPosts = await getCollection("external");
+
+const allPosts: Post[] = [
+    ...blogPosts.map((post) => ({
+        type: "blog" as const,
+        slug: post.slug,
+        title: post.data.title,
+        pubDate: post.data.pubDate,
+    })),
+    ...externalPosts.map((post) => ({
+        type: "external" as const,
+        slug: post.slug,
+        title: post.data.title,
+        pubDate: post.data.pubDate,
+        url: post.data.url,
+        platform: post.data.platform,
+    })),
+].sort((a, b) => b.pubDate.valueOf() - a.pubDate.valueOf());
 
 // 年ごとにグループ化
-const postsByYear = posts.reduce(
+const postsByYear = allPosts.reduce(
     (acc, post) => {
-        const year = post.data.pubDate.getFullYear();
+        const year = post.pubDate.getFullYear();
         if (!acc[year]) acc[year] = [];
         acc[year].push(post);
         return acc;
     },
-    {} as Record<number, typeof posts>,
+    {} as Record<number, Post[]>,
 );
 
 const years = Object.keys(postsByYear)
@@ -30,6 +55,13 @@ const formatDate = (date: Date) => {
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
+};
+
+// プラットフォーム表示名
+const platformLabels: Record<string, string> = {
+    zenn: "Zenn",
+    qiita: "Qiita",
+    other: "External",
 };
 ---
 
@@ -77,6 +109,30 @@ const formatDate = (date: Date) => {
             .title {
                 color: inherit;
             }
+            .platform-tag {
+                font-size: 0.75rem;
+                padding: 0.125rem 0.375rem;
+                border-radius: 3px;
+                margin-left: 0.5rem;
+                font-weight: 500;
+            }
+            .platform-zenn {
+                background-color: #3ea8ff;
+                color: white;
+            }
+            .platform-qiita {
+                background-color: #55c500;
+                color: white;
+            }
+            .platform-other {
+                background-color: rgb(var(--gray));
+                color: white;
+            }
+            .external-icon {
+                font-size: 0.75rem;
+                margin-left: 0.25rem;
+                opacity: 0.7;
+            }
             @media (max-width: 720px) {
                 .year-section {
                     margin-bottom: 1.5rem;
@@ -104,14 +160,37 @@ const formatDate = (date: Date) => {
                         <ul>
                             {postsByYear[year].map((post) => (
                                 <li>
-                                    <a href={`/${post.slug}/`}>
-                                        <span class="date">
-                                            {formatDate(post.data.pubDate)}
-                                        </span>
-                                        <span class="title">
-                                            {post.data.title}
-                                        </span>
-                                    </a>
+                                    {post.type === "blog" ? (
+                                        <a href={`/${post.slug}/`}>
+                                            <span class="date">
+                                                {formatDate(post.pubDate)}
+                                            </span>
+                                            <span class="title">
+                                                {post.title}
+                                            </span>
+                                        </a>
+                                    ) : (
+                                        <a
+                                            href={post.url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            <span class="date">
+                                                {formatDate(post.pubDate)}
+                                            </span>
+                                            <span class="title">
+                                                {post.title}
+                                            </span>
+                                            <span class="external-icon">↗</span>
+                                            {post.platform && (
+                                                <span
+                                                    class={`platform-tag platform-${post.platform}`}
+                                                >
+                                                    {platformLabels[post.platform]}
+                                                </span>
+                                            )}
+                                        </a>
+                                    )}
                                 </li>
                             ))}
                         </ul>


### PR DESCRIPTION
## Summary
- ZennやQiitaなど外部プラットフォームの記事をトップページに表示する機能を追加
- 外部記事は手動でMarkdownファイルとして管理し、自分のブログ記事と時系列で混在表示
- プラットフォームタグ（Zenn: 青、Qiita: 緑）と外部リンクアイコンで視覚的に区別

## Changes
- `src/content/config.ts`: external コレクションを追加
- `src/pages/index.astro`: 両コレクションをマージして表示
- `frontmatter.json`: Front Matter CMS設定を追加
- `CLAUDE.md`, `README.md`: ドキュメントを追加
- ZennとQiitaから既存記事26件を取り込み

## Test plan
- [x] ビルドが正常に完了することを確認
- [x] 開発サーバーでトップページの表示を確認
- [x] 外部記事のリンクが新規タブで開くことを確認

Closes EDG-462

🤖 Generated with [Claude Code](https://claude.com/claude-code)