### PR TITLE
fix: Headerのレスポンシブ対応を改善

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -44,7 +44,7 @@ import { SITE_TITLE } from "../consts";
     }
     h2 {
         margin: 0;
-        font-size: 0.8em;
+        font-size: 1.2em;
     }
 
     h2 a,
@@ -71,11 +71,15 @@ import { SITE_TITLE } from "../consts";
         display: flex;
     }
     @media (max-width: 720px) {
-        .social-links {
-            display: none;
-        }
         nav a {
-            padding: 1.5em 0.5em;
+            padding: 0.75em 0.5em;
+        }
+        .social-links a {
+            padding: 0.75em 0.25em;
+        }
+        .social-links svg {
+            width: 24px;
+            height: 24px;
         }
     }
 </style>


### PR DESCRIPTION
## Summary
- モバイル時もX/GitHubリンクを表示するように修正
- モバイル時のpaddingとアイコンサイズを調整
- PCでのサイトタイトルのフォントサイズを拡大（0.8em → 1.2em）

## Test plan
- [ ] PC表示でヘッダーのタイトルサイズが適切か確認
- [ ] モバイル表示（720px以下）でX/GitHubリンクが表示されるか確認
- [ ] モバイル表示でヘッダーの高さが適切か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)