### PR TITLE
feat: 年単位アコーディオン機能の追加と外部記事の拡充

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -18,7 +18,7 @@ const external = defineCollection({
 		title: z.string(),
 		pubDate: z.coerce.date(),
 		url: z.string().url(),
-		platform: z.enum(['zenn', 'qiita', 'other']),
+		platform: z.enum(['zenn', 'qiita', 'speakerdeck', 'other']),
 	}),
 });
 

--- a/src/content/external/2021-10-18-JavaScriptの画面描画後の実行タイミングについて.md
+++ b/src/content/external/2021-10-18-JavaScriptの画面描画後の実行タイミングについて.md
@@ -1,0 +1,6 @@
+---
+title: "JavaScriptの画面描画後の実行タイミングについて"
+pubDate: 2021-10-18
+url: https://qiita.com/ryosuke-horie/items/7f61c8fd44140a4d1d10
+platform: qiita
+---

--- a/src/content/external/2022-04-11-jQuery-submit()を使ったのにフォームのPOSTが出来ない.md
+++ b/src/content/external/2022-04-11-jQuery-submit()を使ったのにフォームのPOSTが出来ない.md
@@ -1,0 +1,6 @@
+---
+title: "【jQuery】submit()を使ったのにフォームのPOSTが出来ない"
+pubDate: 2022-04-11
+url: https://qiita.com/ryosuke-horie/items/f4d86879cb088275dece
+platform: qiita
+---

--- a/src/content/external/2022-04-13-Git-リポジトリの変更時に差分を入れたい.md
+++ b/src/content/external/2022-04-13-Git-リポジトリの変更時に差分を入れたい.md
@@ -1,0 +1,6 @@
+---
+title: "【Git】リポジトリの変更時に差分を入れたい"
+pubDate: 2022-04-13
+url: https://qiita.com/ryosuke-horie/items/c87ff8536949a718ff55
+platform: qiita
+---

--- a/src/content/external/2022-08-05-個人開発-GAS-QiitaトレンドをGmailで送信するプログラムを作る.md
+++ b/src/content/external/2022-08-05-個人開発-GAS-QiitaトレンドをGmailで送信するプログラムを作る.md
@@ -1,0 +1,6 @@
+---
+title: "【個人開発 | GAS】QiitaトレンドをGmailで送信するプログラムを作る"
+pubDate: 2022-08-05
+url: https://qiita.com/ryosuke-horie/items/772e48926a2810671be7
+platform: qiita
+---

--- a/src/content/external/2022-08-31-laravel-改行コードを含む文字列をDBから取得しbladeで表示させる方法.md
+++ b/src/content/external/2022-08-31-laravel-改行コードを含む文字列をDBから取得しbladeで表示させる方法.md
@@ -1,0 +1,6 @@
+---
+title: "【laravel】改行コードを含む文字列をDBから取得しbladeで表示させる方法"
+pubDate: 2022-08-31
+url: https://qiita.com/ryosuke-horie/items/0b36cd986e0704784a61
+platform: qiita
+---

--- a/src/content/external/2022-09-01-Cloud9でphpMyAdminを使用する方法.md
+++ b/src/content/external/2022-09-01-Cloud9でphpMyAdminを使用する方法.md
@@ -1,0 +1,6 @@
+---
+title: "Cloud9でphpMyAdminを使用する方法"
+pubDate: 2022-09-01
+url: https://qiita.com/ryosuke-horie/items/29705d3fafa6e58cfb2e
+platform: qiita
+---

--- a/src/content/external/2022-10-03-PHPStorm起動後のインデックス作成の制御.md
+++ b/src/content/external/2022-10-03-PHPStorm起動後のインデックス作成の制御.md
@@ -1,0 +1,6 @@
+---
+title: "PHPStorm起動後のインデックス作成の制御"
+pubDate: 2022-10-03
+url: https://qiita.com/ryosuke-horie/items/d7629b6a641f98ad6372
+platform: qiita
+---

--- a/src/content/external/2022-10-11-PHP-sprintf関数の意味・動作.md
+++ b/src/content/external/2022-10-11-PHP-sprintf関数の意味・動作.md
@@ -1,0 +1,6 @@
+---
+title: "PHP sprintf関数の意味・動作"
+pubDate: 2022-10-11
+url: https://qiita.com/ryosuke-horie/items/32011aec02211b13c531
+platform: qiita
+---

--- a/src/content/external/2022-12-09-Laravelでassets関数を使用した部分のcss・jsが読み込まれない.md
+++ b/src/content/external/2022-12-09-Laravelでassets関数を使用した部分のcss・jsが読み込まれない.md
@@ -1,0 +1,6 @@
+---
+title: "Laravelでassets関数を使用した部分のcss・jsが読み込まれない"
+pubDate: 2022-12-09
+url: https://qiita.com/ryosuke-horie/items/89d227d982acafabb6a2
+platform: qiita
+---

--- a/src/content/external/2022-12-20-PHP-$_SERVERが環境によって想定どうりに動いてくれない落とし穴.md
+++ b/src/content/external/2022-12-20-PHP-$_SERVERが環境によって想定どうりに動いてくれない落とし穴.md
@@ -1,0 +1,6 @@
+---
+title: "【PHP】$_SERVERが環境によって想定どうりに動いてくれない【落とし穴】"
+pubDate: 2022-12-20
+url: https://qiita.com/ryosuke-horie/items/045703c78a12c298a4e7
+platform: qiita
+---

--- a/src/content/external/2022-12-30-ABテストについて.md
+++ b/src/content/external/2022-12-30-ABテストについて.md
@@ -1,0 +1,6 @@
+---
+title: "ABテストについて"
+pubDate: 2022-12-30
+url: https://qiita.com/ryosuke-horie/items/009fd43093e7ed769e73
+platform: qiita
+---

--- a/src/content/external/2023-02-12-Lambda-Typescript-技術のトレンドを追うために簡単なアプリケーションをつくりました.md
+++ b/src/content/external/2023-02-12-Lambda-Typescript-技術のトレンドを追うために簡単なアプリケーションをつくりました.md
@@ -1,0 +1,6 @@
+---
+title: "【Lambda Typescript】技術のトレンドを追うために簡単なアプリケーションをつくりました"
+pubDate: 2023-02-12
+url: https://qiita.com/ryosuke-horie/items/c397921e05f1d8196d77
+platform: qiita
+---

--- a/src/content/external/2023-03-12-PHP-インターフェースを利用するメリット-書籍「良いコード悪いコードで学ぶ設計入門」6章アウトプッ.md
+++ b/src/content/external/2023-03-12-PHP-インターフェースを利用するメリット-書籍「良いコード悪いコードで学ぶ設計入門」6章アウトプッ.md
@@ -1,0 +1,6 @@
+---
+title: "【PHP】インターフェースを利用するメリット｜書籍「良いコード/悪いコードで学ぶ設計入門」6章アウトプット"
+pubDate: 2023-03-12
+url: https://qiita.com/ryosuke-horie/items/906d241e32326230dabb
+platform: qiita
+---

--- a/src/content/external/2023-05-01-AWS-CLF-合格体験記.md
+++ b/src/content/external/2023-05-01-AWS-CLF-合格体験記.md
@@ -1,0 +1,6 @@
+---
+title: "AWS CLF 合格体験記"
+pubDate: 2023-05-01
+url: https://qiita.com/ryosuke-horie/items/19d6ca6d2c804a9fe4db
+platform: qiita
+---

--- a/src/content/external/2023-05-01-CloudVisonAPI-シフト表からカレンダーに予定を入れる作業を自動化したいPython.md
+++ b/src/content/external/2023-05-01-CloudVisonAPI-シフト表からカレンダーに予定を入れる作業を自動化したいPython.md
@@ -1,0 +1,6 @@
+---
+title: "【CloudVisonAPI】シフト表からカレンダーに予定を入れる作業を自動化したい【Python】"
+pubDate: 2023-05-01
+url: https://qiita.com/ryosuke-horie/items/d0b9b73b3af5d19bb1c7
+platform: qiita
+---

--- a/src/content/external/2023-05-02-AWS-1年間無料利用枠-まとめ.md
+++ b/src/content/external/2023-05-02-AWS-1年間無料利用枠-まとめ.md
@@ -1,0 +1,6 @@
+---
+title: "AWS 1年間無料利用枠 まとめ"
+pubDate: 2023-05-02
+url: https://qiita.com/ryosuke-horie/items/14a979fbfae3295f5b6c
+platform: qiita
+---

--- a/src/content/external/2023-05-02-AWS-Amplifyを利用してReactコードを自動生成してみる.md
+++ b/src/content/external/2023-05-02-AWS-Amplifyを利用してReactコードを自動生成してみる.md
@@ -1,0 +1,6 @@
+---
+title: "AWS Amplifyを利用してReactコードを自動生成してみる"
+pubDate: 2023-05-02
+url: https://qiita.com/ryosuke-horie/items/6acae5a0097e79e4c91e
+platform: qiita
+---

--- a/src/content/external/2023-05-11-Github-Copilotを活用する上でのおさえておくべき特徴とTips.md
+++ b/src/content/external/2023-05-11-Github-Copilotを活用する上でのおさえておくべき特徴とTips.md
@@ -1,0 +1,6 @@
+---
+title: "Github Copilotを活用する上でのおさえておくべき特徴とTips"
+pubDate: 2023-05-11
+url: https://qiita.com/ryosuke-horie/items/39ba28294fc4bbfc8722
+platform: qiita
+---

--- a/src/content/external/2023-05-18-PhpStorm-関数などの使用箇所の表示位置を変更する.md
+++ b/src/content/external/2023-05-18-PhpStorm-関数などの使用箇所の表示位置を変更する.md
@@ -1,0 +1,6 @@
+---
+title: "【PhpStorm】関数などの使用箇所の表示位置を変更する"
+pubDate: 2023-05-18
+url: https://qiita.com/ryosuke-horie/items/93cd1d900277f9deda93
+platform: qiita
+---

--- a/src/content/external/2023-05-19-ChatGPTとUdemyで効率的に学ぶ方法-AWSとLaravelを例に紹介.md
+++ b/src/content/external/2023-05-19-ChatGPTとUdemyで効率的に学ぶ方法-AWSとLaravelを例に紹介.md
@@ -1,0 +1,6 @@
+---
+title: "【ChatGPTとUdemyで効率的に学ぶ方法】AWSとLaravelを例に紹介"
+pubDate: 2023-05-19
+url: https://qiita.com/ryosuke-horie/items/d05beb5ba33ba787e781
+platform: qiita
+---

--- a/src/content/external/2023-05-23-初心者-React,Next.jsの門をたたくために利用した教材の共有JavaScript~Next.md
+++ b/src/content/external/2023-05-23-初心者-React,Next.jsの門をたたくために利用した教材の共有JavaScript~Next.md
@@ -1,0 +1,6 @@
+---
+title: "【初心者】React,Next.jsの門をたたくために利用した教材の共有【JavaScript~Next.js】"
+pubDate: 2023-05-23
+url: https://qiita.com/ryosuke-horie/items/7599bca808c6f0a6e5b4
+platform: qiita
+---

--- a/src/content/external/2023-05-25-「技術書」の読書術-を読んで個人的に使っていきたいTips.md
+++ b/src/content/external/2023-05-25-「技術書」の読書術-を読んで個人的に使っていきたいTips.md
@@ -1,0 +1,6 @@
+---
+title: "「技術書」の読書術 を読んで個人的に使っていきたいTips"
+pubDate: 2023-05-25
+url: https://qiita.com/ryosuke-horie/items/36aca08bd4ff4378b8df
+platform: qiita
+---

--- a/src/content/external/2023-06-08-Next.jsでAPIからデータを取得するために利用するReact-Hooks.md
+++ b/src/content/external/2023-06-08-Next.jsでAPIからデータを取得するために利用するReact-Hooks.md
@@ -1,0 +1,6 @@
+---
+title: "Next.jsでAPIからデータを取得するために利用するReact Hooks"
+pubDate: 2023-06-08
+url: https://qiita.com/ryosuke-horie/items/303ac10049e2fce7176b
+platform: qiita
+---

--- a/src/content/external/2023-06-24-例外処理のテストについての学習メモテスト-TypeScript.md
+++ b/src/content/external/2023-06-24-例外処理のテストについての学習メモテスト-TypeScript.md
@@ -1,0 +1,6 @@
+---
+title: "例外処理のテストについての学習メモ【テスト】【TypeScript】"
+pubDate: 2023-06-24
+url: https://qiita.com/ryosuke-horie/items/9b025001f0fb6fb0704a
+platform: qiita
+---

--- a/src/content/external/2023-06-26-バックエンドエンジニアがデザインとフロントエンドに挑戦してみた.md
+++ b/src/content/external/2023-06-26-バックエンドエンジニアがデザインとフロントエンドに挑戦してみた.md
@@ -1,0 +1,6 @@
+---
+title: "バックエンドエンジニアがデザインとフロントエンドに挑戦してみた"
+pubDate: 2023-06-26
+url: https://speakerdeck.com/hreryosuke03/batukuendoenziniagadezaintohurontoendonitiao-zhan-sitemita
+platform: speakerdeck
+---

--- a/src/content/external/2023-06-27-レガシーな開発環境と向き合うエンジニアのキャリアプラン.md
+++ b/src/content/external/2023-06-27-レガシーな開発環境と向き合うエンジニアのキャリアプラン.md
@@ -1,0 +1,6 @@
+---
+title: "レガシーな開発環境と向き合うエンジニアのキャリアプラン"
+pubDate: 2023-06-27
+url: https://qiita.com/ryosuke-horie/items/d162640350dedb32a712
+platform: qiita
+---

--- a/src/content/external/2023-07-02-個人開発の醍醐味：自分の興味に基づいた技術の積極的な導入.md
+++ b/src/content/external/2023-07-02-個人開発の醍醐味：自分の興味に基づいた技術の積極的な導入.md
@@ -1,0 +1,6 @@
+---
+title: "個人開発の醍醐味：自分の興味に基づいた技術の積極的な導入"
+pubDate: 2023-07-02
+url: https://qiita.com/ryosuke-horie/items/8164818756def5385311
+platform: qiita
+---

--- a/src/content/external/2023-07-17-Todoアプリを作成してNest.jsのキャッチアップをしてみた.md
+++ b/src/content/external/2023-07-17-Todoアプリを作成してNest.jsのキャッチアップをしてみた.md
@@ -1,0 +1,6 @@
+---
+title: "Todoアプリを作成してNest.jsのキャッチアップをしてみた"
+pubDate: 2023-07-17
+url: https://qiita.com/ryosuke-horie/items/600fa649002fa3738853
+platform: qiita
+---

--- a/src/content/external/2023-08-01-Nest.js-TypeORMとDBの接続設定について.md
+++ b/src/content/external/2023-08-01-Nest.js-TypeORMとDBの接続設定について.md
@@ -1,0 +1,6 @@
+---
+title: "Nest.js TypeORMとDBの接続設定について"
+pubDate: 2023-08-01
+url: https://qiita.com/ryosuke-horie/items/f16213cbd3e355cc0478
+platform: qiita
+---

--- a/src/content/external/2023-08-02-GA4キャッチアップ-探索を活用したユーザー数の推移の分析.md
+++ b/src/content/external/2023-08-02-GA4キャッチアップ-探索を活用したユーザー数の推移の分析.md
@@ -1,0 +1,6 @@
+---
+title: "【GA4キャッチアップ】探索を活用したユーザー数の推移の分析"
+pubDate: 2023-08-02
+url: https://qiita.com/ryosuke-horie/items/4efde4b49050bc2d0421
+platform: qiita
+---

--- a/src/content/external/2023-08-09-Nest.jsで認証機能を実装するメモ.md
+++ b/src/content/external/2023-08-09-Nest.jsで認証機能を実装するメモ.md
@@ -1,0 +1,6 @@
+---
+title: "Nest.jsで認証機能を実装するメモ"
+pubDate: 2023-08-09
+url: https://qiita.com/ryosuke-horie/items/0a276fb5ea17e7118471
+platform: qiita
+---

--- a/src/content/external/2023-09-20-Laravel-+-Vue-+-ViteのIPでアクセスできる開発環境を構築する.md
+++ b/src/content/external/2023-09-20-Laravel-+-Vue-+-ViteのIPでアクセスできる開発環境を構築する.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel + Vue + ViteのIPでアクセスできる開発環境を構築する"
+pubDate: 2023-09-20
+url: https://qiita.com/ryosuke-horie/items/335b8f1962048b720d8c
+platform: qiita
+---

--- a/src/content/external/2023-09-20-Vue3-+-Viteを仮想OS上でDockerを利用して作成.md
+++ b/src/content/external/2023-09-20-Vue3-+-Viteを仮想OS上でDockerを利用して作成.md
@@ -1,0 +1,6 @@
+---
+title: "Vue3 + Viteを仮想OS上でDockerを利用して作成"
+pubDate: 2023-09-20
+url: https://qiita.com/ryosuke-horie/items/d1047a1f69ca219bfc5e
+platform: qiita
+---

--- a/src/content/external/2023-09-21-Laravel-+-Vue-+-Vite-+-inertia.js-環境構築(IPでアクセスするとき.md
+++ b/src/content/external/2023-09-21-Laravel-+-Vue-+-Vite-+-inertia.js-環境構築(IPでアクセスするとき.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel + Vue + Vite + inertia.js 環境構築(IPでアクセスするとき)"
+pubDate: 2023-09-21
+url: https://qiita.com/ryosuke-horie/items/f27e36f44be8ec11b2f5
+platform: qiita
+---

--- a/src/content/external/2023-09-24-Laravel-+-Vue-+-Vite-+-Inertia.js-Docker開発環境の構築.md
+++ b/src/content/external/2023-09-24-Laravel-+-Vue-+-Vite-+-Inertia.js-Docker開発環境の構築.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel + Vue + Vite + Inertia.js Docker開発環境の構築"
+pubDate: 2023-09-24
+url: https://qiita.com/ryosuke-horie/items/4ee6eb332a7041426a9c
+platform: qiita
+---

--- a/src/content/external/2023-09-24-Laravel-+-Vue-+-Vite-+-Inertia.js環境にSSRを導入する.md
+++ b/src/content/external/2023-09-24-Laravel-+-Vue-+-Vite-+-Inertia.js環境にSSRを導入する.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel + Vue + Vite + Inertia.js環境にSSRを導入する"
+pubDate: 2023-09-24
+url: https://qiita.com/ryosuke-horie/items/76da2e23ed283fccb852
+platform: qiita
+---

--- a/src/content/external/2023-09-25-DockerのImagesを作りすぎて新しいDocker環境がつくれなくなった.md
+++ b/src/content/external/2023-09-25-DockerのImagesを作りすぎて新しいDocker環境がつくれなくなった.md
@@ -1,0 +1,6 @@
+---
+title: "DockerのImagesを作りすぎて新しいDocker環境がつくれなくなった"
+pubDate: 2023-09-25
+url: https://qiita.com/ryosuke-horie/items/d647c2e7a09b137f8a86
+platform: qiita
+---

--- a/src/content/external/2023-11-19-Laravel学習メモ：Request.md
+++ b/src/content/external/2023-11-19-Laravel学習メモ：Request.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel学習メモ：Request"
+pubDate: 2023-11-19
+url: https://qiita.com/ryosuke-horie/items/05f794c8dd0ae8f0f0a1
+platform: qiita
+---

--- a/src/content/external/2023-11-19-Laravel学習メモ：サービスコンテナ.md
+++ b/src/content/external/2023-11-19-Laravel学習メモ：サービスコンテナ.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel学習メモ：サービスコンテナ"
+pubDate: 2023-11-19
+url: https://qiita.com/ryosuke-horie/items/58a74fa9d3bddd312918
+platform: qiita
+---

--- a/src/content/external/2023-11-19-Laravel学習メモ：サービスプロバイダ.md
+++ b/src/content/external/2023-11-19-Laravel学習メモ：サービスプロバイダ.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel学習メモ：サービスプロバイダ"
+pubDate: 2023-11-19
+url: https://qiita.com/ryosuke-horie/items/3eeba81b6258986cc134
+platform: qiita
+---

--- a/src/content/external/2023-11-19-Laravel学習メモ：ファサード.md
+++ b/src/content/external/2023-11-19-Laravel学習メモ：ファサード.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel学習メモ：ファサード"
+pubDate: 2023-11-19
+url: https://qiita.com/ryosuke-horie/items/d75a0572ec85847e2ebc
+platform: qiita
+---

--- a/src/content/external/2023-11-19-Laravel学習メモ：リクエストのライフサイクル.md
+++ b/src/content/external/2023-11-19-Laravel学習メモ：リクエストのライフサイクル.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel学習メモ：リクエストのライフサイクル"
+pubDate: 2023-11-19
+url: https://qiita.com/ryosuke-horie/items/84122f70e8bbabd2c855
+platform: qiita
+---

--- a/src/content/external/2023-11-20-Laravel学習メモ：コレクション.md
+++ b/src/content/external/2023-11-20-Laravel学習メモ：コレクション.md
@@ -1,0 +1,6 @@
+---
+title: "Laravel学習メモ：コレクション"
+pubDate: 2023-11-20
+url: https://qiita.com/ryosuke-horie/items/cb20bc6a1b04f569d23b
+platform: qiita
+---

--- a/src/content/external/2024-05-25-社内AWSインフラのIaC化にCDKを提案する資料.md
+++ b/src/content/external/2024-05-25-社内AWSインフラのIaC化にCDKを提案する資料.md
@@ -1,0 +1,6 @@
+---
+title: "社内AWSインフラのIaC化にCDKを提案する資料"
+pubDate: 2024-05-25
+url: https://speakerdeck.com/hreryosuke03/she-nei-awsinhuranoiachua-nicdkwoti-an-suruzi-liao
+platform: speakerdeck
+---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ type Post = {
     title: string;
     pubDate: Date;
     url?: string;
-    platform?: "zenn" | "qiita" | "other";
+    platform?: "zenn" | "qiita" | "speakerdeck" | "other";
 };
 
 const blogPosts = await getCollection("blog");
@@ -61,6 +61,7 @@ const formatDate = (date: Date) => {
 const platformLabels: Record<string, string> = {
     zenn: "Zenn",
     qiita: "Qiita",
+    speakerdeck: "SpeakerDeck",
     other: "External",
 };
 ---
@@ -75,14 +76,38 @@ const platformLabels: Record<string, string> = {
             }
             .year-section {
                 margin-bottom: 2rem;
+                border-bottom: 1px solid rgb(var(--gray-light));
             }
             .year-heading {
                 font-size: 1.5rem;
                 font-weight: bold;
                 margin: 0 0 1rem 0;
+                padding: 0.5rem 0;
                 color: rgb(var(--black));
-                border-bottom: 1px solid rgb(var(--gray-light));
-                padding-bottom: 0.5rem;
+                cursor: pointer;
+                list-style: none;
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+            }
+            .year-heading::-webkit-details-marker {
+                display: none;
+            }
+            .year-heading::before {
+                content: "▶";
+                font-size: 0.75rem;
+                transition: transform 0.2s ease;
+            }
+            .year-section[open] > .year-heading::before {
+                transform: rotate(90deg);
+            }
+            .year-heading:hover {
+                color: rgb(var(--accent));
+            }
+            .post-count {
+                font-size: 0.875rem;
+                font-weight: normal;
+                color: rgb(var(--gray));
             }
             ul {
                 list-style-type: none;
@@ -124,6 +149,10 @@ const platformLabels: Record<string, string> = {
                 background-color: #55c500;
                 color: white;
             }
+            .platform-speakerdeck {
+                background-color: #009287;
+                color: white;
+            }
             .platform-other {
                 background-color: rgb(var(--gray));
                 color: white;
@@ -155,8 +184,11 @@ const platformLabels: Record<string, string> = {
         <main>
             {
                 years.map((year) => (
-                    <section class="year-section">
-                        <h2 class="year-heading">{year}</h2>
+                    <details class="year-section" open>
+                        <summary class="year-heading">
+                            {year}
+                            <span class="post-count">({postsByYear[year].length}件)</span>
+                        </summary>
                         <ul>
                             {postsByYear[year].map((post) => (
                                 <li>
@@ -194,7 +226,7 @@ const platformLabels: Record<string, string> = {
                                 </li>
                             ))}
                         </ul>
-                    </section>
+                    </details>
                 ))
             }
         </main>


### PR DESCRIPTION
## Summary
- トップページの記事一覧を年単位で折りたためるアコーディオン機能を追加
- 各年の記事件数を表示（例: `2025 (12件)`）
- Qiitaの不足記事42件を追加（2021年〜2023年）
- SpeakerDeckのスライド2件を追加
- SpeakerDeck用のplatformを新規追加（ティール色のラベル）

## Test plan
- [ ] トップページでアコーディオンの開閉が正常に動作する
- [ ] 全年がデフォルトで開いた状態で表示される
- [ ] 各年の件数が正しく表示される
- [ ] Qiita記事へのリンクが正常に機能する
- [ ] SpeakerDeckのスライドへのリンクが正常に機能し、ラベルが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)